### PR TITLE
Fix up state loading in emscripten and update TOTAL_MEMORY vs INITIAL_MEMPORY

### DIFF
--- a/libhalfix.js
+++ b/libhalfix.js
@@ -182,7 +182,7 @@
         }
 
         this.total_memory = roundUp(mem + 32 + vgamem) * 1024 * 1024 | 0;
-        //Module["TOTAL_MEMORY"] = roundUp(mem + 32 + vgamem) * 1024 * 1024 | 0;
+        //Module["INITIAL_MEMORY"] = roundUp(mem + 32 + vgamem) * 1024 * 1024 | 0;
         config.push("memory=" + mem + "M");
         config.push("vgamemory=" + vgamem + "M");
         this.buildDrive(config, "a", 0, "master");
@@ -286,7 +286,7 @@
 
         // Set up our module instance
         global["Module"]["canvas"] = this.canvas;
-        global["Module"]["TOTAL_MEMORY"] = this.total_memory;
+        global["Module"]["INITIAL_MEMORY"] = this.total_memory;
 
         init_cb = cb;
 
@@ -308,6 +308,7 @@
      * @param {function} cb
      */
     Halfix.prototype["loadStateXHR"] = function (statepath, cb) {
+        var me = this;
         loadFiles([
             statepath + "/state.bin",
             statepath + "/ram",
@@ -519,7 +520,6 @@
             strcpy(strptr, p);
             wrap("drive_emscripten_init")(info_ptr, strptr, dataptr, id);
             gc();
-
             global["drives"][id] = image;
             requests_in_progress = requests_in_progress - 1 | 0;
             if (requests_in_progress === 0) run_wrapper2();

--- a/src/drive.c
+++ b/src/drive.c
@@ -109,6 +109,7 @@ static void join_path(char* dest, int alen, char* a, char* b)
         alen++;
     }
     strcpy(dest + alen, b);
+
 }
 
 static void drive_get_path(char* dest, char* pathbase, uint32_t x)
@@ -562,7 +563,7 @@ static void drive_internal_state(void* this_ptr, char* pn)
     struct bjson_object* obj = state_obj(pn, 4 + this->path_count + 1);
 
     state_field(obj, 4, "size", &this->size);
-    //state_field(obj, 4, "path_count", &this->path_count);
+    state_field(obj, 4, "path_count", &this->path_count);
     state_field(obj, 4, "block_count", &this->block_count);
     uint32_t* block_infos = alloca(this->block_count * 4);
 

--- a/src/emscripten/emscripten.c
+++ b/src/emscripten/emscripten.c
@@ -82,6 +82,11 @@ void emscripten_savestate(void){
 }
 
 EMSCRIPTEN_KEEPALIVE
+void emscripten_load_state(void){
+    state_read_from_file("");
+}
+
+EMSCRIPTEN_KEEPALIVE
 double emscripten_get_cycles(void){
     return (double)cpu_get_cycles();
 }


### PR DESCRIPTION
Emscripten 2.0.11 didn't like `TOTAL_MEMORY` so replaced with `INITIAL_MEMORY`
Added (back?) state loading into emscripten, fixes issue #15 