### PR TITLE
Update `src/hardware/apic.c` fix format string errors on M1 Mac

### DIFF
--- a/src/hardware/apic.c
+++ b/src/hardware/apic.c
@@ -559,7 +559,7 @@ int apic_next(itick_t now)
     if (apic.timer_next <= now) {
         // Raise interrupt
         if(!(info & 1)) {// LVT_DISABLED set to 0
-            APIC_LOG("  timer period %ld cur=%ld next=%ld\n", apic_get_period(), now, apic.timer_next);
+            APIC_LOG("  timer period %llu cur=%llu next=%llu\n", apic_get_period(), now, apic.timer_next);
             apic_receive_bus_message(apic.lvt[LVT_INDEX_TIMER] & 0xFF, LVT_DELIVERY_FIXED, 0);
         }
         else apic_timer_enabled = 0;


### PR DESCRIPTION
This line caused compile issue with long with llu.

<img width="1105" alt="image" src="https://user-images.githubusercontent.com/399864/195788009-26ad85f7-4a9e-4e61-b0d8-3f09ab474f3c.png">

An alternative solution would be hard casting the args to (long).

```js
APIC_LOG("  timer period %ld cur=%ld next=%ld\n", (long)apic_get_period(), (long)now, (long)apic.timer_next);
```